### PR TITLE
Fixed PNG output error when widht is not multiple of 8.

### DIFF
--- a/image.c
+++ b/image.c
@@ -167,7 +167,10 @@ static unsigned char *repack1bpp(const Image *i, int *packed_len)
 			if (--b == 0) { *tmp++ ^= mask; b = 8; }
 			*tmp = (*tmp << 1) | *p++;
 		}
+		if (b > 1)
+			*tmp = *tmp << (b - 1);
 		*tmp++ ^= mask;
+	
 	}
 	*packed_len = len;
 	return out;


### PR DESCRIPTION
If output width is not multiple of 8, rightest pixel is drawn incorrectly.
For example:
./iec16022 --format=PNG -c "DataMatrix" --size=16x16 
would produce image of 18x18, in which rightest 2 pixels are not shown.

Before:
![before](https://user-images.githubusercontent.com/17998811/43176621-0f9dd606-8ff7-11e8-8d03-b72d29d768ac.png)

After:
![after](https://user-images.githubusercontent.com/17998811/43176622-11e1d12e-8ff7-11e8-9622-a76131db2ce4.png)
